### PR TITLE
Copy on write

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -24,11 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: clippy
       - name: Run cargo clippy
         run: cargo clippy --all
 
@@ -37,10 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
       - name: Run cargo test
         run: cargo test --all
 
@@ -49,10 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
       - name: Run cargo build
         run: cargo build --release
 
@@ -61,10 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
       - name: Run cargo audit
         run: cargo install cargo-audit && cargo audit
 
@@ -73,9 +51,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
       - name: Run cargo doc
         run: cargo doc --all --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-banner"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["muji <muji@tmpfs.org>"]
 description = "Render a banner to the terminal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-banner"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["muji <muji@tmpfs.org>"]
 description = "Render a banner to the terminal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod text;
 
 pub use text::{Text, TextAlign, TextStyle};
 
+#[cfg(feature = "color")]
+pub use colored;
+
 /// Collection of box drawing symbols used to draw the banner outline.
 pub struct BoxSymbols {
     tl: char,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,21 +87,21 @@ impl Padding {
     }
 }
 
-enum Line {
-    Text(Text),
+enum Line<'a> {
+    Text(Text<'a>),
     Divider(char),
 }
 
 /// Render a terminal banner.
 #[derive(Default)]
-pub struct Banner {
+pub struct Banner<'a> {
     symbols: BoxSymbols,
-    lines: Vec<Line>,
+    lines: Vec<Line<'a>>,
     padding: Padding,
     width: Option<usize>,
 }
 
-impl Banner {
+impl<'a> Banner<'a> {
     /// Create a new banner.
     pub fn new() -> Self {
         Default::default()
@@ -126,7 +126,7 @@ impl Banner {
     }
 
     /// Append a block of text to wrap inside the banner.
-    pub fn text(mut self, text: Text) -> Self {
+    pub fn text(mut self, text: Text<'a>) -> Self {
         self.lines.push(Line::Text(text));
         self
     }
@@ -211,7 +211,7 @@ impl Banner {
                         } else {
                             repeat
                         });
-                    context.push_str(text.content.as_str());
+                    context.push_str(text.content.as_ref());
                     let lines = wrap(context.as_str(), &options);
                     let length = lines.len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Tiny utility to render a boxed banner at the width of the terminal.
 //!
-//! Use the `color` feature to enable support for terminal colors, 
+//! Use the `color` feature to enable support for terminal colors,
 //! see the examples for usage.
 //!
 //! ```

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
 #[cfg(feature = "color")]
 use colored::Color;
+use std::borrow::Cow;
 
 /// Variants for text alignment.
 #[derive(Default, Copy, Clone)]
@@ -49,7 +49,7 @@ impl<'a> Text<'a> {
         self.style.align = align;
         self
     }
-    
+
     /// Set the text color.
     #[cfg(feature = "color")]
     pub fn color(mut self, color: Color) -> Self {

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "color")]
 use colored::Color;
 
@@ -15,9 +16,9 @@ pub enum TextAlign {
 
 /// Text content.
 #[derive(Default, Clone)]
-pub struct Text {
+pub struct Text<'a> {
     /// Content for the text.
-    pub content: String,
+    pub content: Cow<'a, str>,
     /// Styling information.
     pub style: TextStyle,
 }
@@ -42,7 +43,7 @@ impl Default for TextStyle {
     }
 }
 
-impl Text {
+impl<'a> Text<'a> {
     /// Set the text alignment.
     pub fn align(mut self, align: TextAlign) -> Self {
         self.style.align = align;
@@ -57,19 +58,28 @@ impl Text {
     }
 }
 
-impl From<String> for Text {
+impl From<String> for Text<'_> {
     fn from(value: String) -> Self {
         Text {
-            content: value,
+            content: Cow::Owned(value),
             ..Default::default()
         }
     }
 }
 
-impl From<&str> for Text {
-    fn from(value: &str) -> Self {
+impl<'a> From<&'a str> for Text<'a> {
+    fn from(value: &'a str) -> Self {
         Text {
-            content: value.to_string(),
+            content: Cow::Borrowed(value),
+            ..Default::default()
+        }
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Text<'a> {
+    fn from(value: Cow<'a, str>) -> Self {
+        Text {
+            content: value,
             ..Default::default()
         }
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -76,6 +76,15 @@ impl<'a> From<&'a str> for Text<'a> {
     }
 }
 
+impl<'a> From<&'a String> for Text<'a> {
+    fn from(value: &'a String) -> Self {
+        Text {
+            content: Cow::Borrowed(value),
+            ..Default::default()
+        }
+    }
+}
+
 impl<'a> From<Cow<'a, str>> for Text<'a> {
     fn from(value: Cow<'a, str>) -> Self {
         Text {


### PR DESCRIPTION
Fix cow usage so that we can also use borrowed strings.

Re-export colored dependency when `color` feature.

/cc @fangzhengjin 